### PR TITLE
Update Ubuntu 20171201 to 20180228

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial-20171201
+FROM ubuntu:xenial-20180228
 
 ENV LANG=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive 
 ENV ENTRYKIT_VERSION=0.4.0


### PR DESCRIPTION
Ubuntuのコンテナイメージの更新

https://hub.docker.com/r/library/ubuntu/tags/
xenial-20180228